### PR TITLE
chore(deps): update all dependencies to latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # nightly
         with:
           toolchain: nightly
           components: rustfmt
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # nightly
         with:
           toolchain: nightly
           components: clippy
@@ -50,15 +50,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # nightly
         with:
           toolchain: nightly
 
       - name: Cache cargo registry & build
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install cargo-audit
         run: cargo install cargo-audit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       release_body: ${{ steps.git-cliff.outputs.content }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -81,10 +81,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # master
+      uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
       with:
         toolchain: ${{ matrix.rust }}
         target: ${{ matrix.target }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.105.0
+    rev: v1.108.0
     hooks:
       - id: terraform_fmt
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,15 +75,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -102,9 +102,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
-version = "1.8.18"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275"
+checksum = "701418aa459dac33e50a0f8e818e5662a16bc018a6ac7423659b70f3799d67a8"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -122,7 +122,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "http 1.4.1",
+ "http 1.4.2",
  "sha1",
  "time",
  "tokio",
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.14"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+checksum = "e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -155,21 +155,22 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.4"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ed8e8c52d2dc2390ad9f15647fe663f71e9780b4262c190fbb823a32721566"
+checksum = "a6b50a43f3ccdf331521c6d6c68b7cc9668b6e09d439ebda9569df5722324d76"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -182,8 +183,8 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "fastrand",
- "http 1.4.1",
- "http-body 1.0.1",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -192,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ec2"
-version = "1.229.0"
+version = "1.241.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb5dfffc70e73ed387efa49d11fa455ef41dfb19df2ca41abafbbf8bb60c9d1"
+checksum = "36d274d82dfee2c5f8c43c023a32605521ff86a0342ed2279c6c02ed5401cefc"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -206,21 +207,22 @@ dependencies = [
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.101.0"
+version = "1.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b647baea49ff551960b904f905681e9b4765a6c4ea08631e89dc52d8bd3f5896"
+checksum = "b53416d16c278234845392e38d93bd4481d2f09daa0f005a2277f0aa91f59c22"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -231,21 +233,22 @@ dependencies = [
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.103.0"
+version = "1.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae401c65ff288aa7873117fe535cd32b7b1bb0bc43751d28901a1d5f20636b9"
+checksum = "cc9b706c3305ed0285d5b1b696c747aa34950f830fb03e3e6c76890f99b9f188"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -256,21 +259,22 @@ dependencies = [
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.106.0"
+version = "1.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c80de7bb7d03e9ca8c9fd7b489f20f3948d3f3be91a7953591347d238115408"
+checksum = "32d214cdfa5bbe17f117e76a7643fadf32a5234fb597322ef8b1fb4b2f17dbbd"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -282,21 +286,22 @@ dependencies = [
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.4"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7083fb918b38474ac65ffbf8a69fc8792d36879f4ac5f1667b43aec61efe9a5"
+checksum = "723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -307,18 +312,18 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "percent-encoding",
- "sha2 0.11.0",
+ "sha2",
  "time",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.14"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -327,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.63.6"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -337,8 +342,8 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.4.1",
- "http-body 1.0.1",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "http-body-util",
  "percent-encoding",
  "pin-project-lite",
@@ -348,15 +353,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.12"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+checksum = "635d23afda0a6ab48d666c4d447c4873e8d1e83518a2be2093122397e50b838e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2",
- "http 1.4.1",
+ "http 1.4.2",
  "hyper",
  "hyper-rustls",
  "hyper-util",
@@ -372,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.7"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
+checksum = "3dc65a121adb4b33729919fcfa14fa36fb33c1555a8f06bb0e2188dbfdc1d9ef"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",
@@ -383,28 +388,31 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.60.15"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+checksum = "512346c7212ab7436df2d77a16d976a468ae44a418835511d2a69269810aaf62"
 dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
+ "aws-smithy-xml",
  "urlencoding",
 ]
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
+checksum = "bea94a9ff8464016338c851e24b472d7131c388c88898a502e781815b2ee6045"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -416,9 +424,9 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 0.4.6",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "pin-project-lite",
  "pin-utils",
@@ -428,16 +436,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
+checksum = "22ed1ebe6e0a95ea84570225f5a8208dec4b8f77e61a9b0d6f51773fcb4612f0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -446,40 +454,40 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api-macros"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "aws-smithy-schema"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http 1.4.1",
+ "http 1.4.2",
 ]
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.9"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f93074121a1be41317b9aa607143ae17900631f7f59a99f2b905d519d6783b"
+checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 0.4.6",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
  "itoa",
  "num-integer",
@@ -494,18 +502,21 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.15"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+checksum = "ce84f71c72fee2cbbadde6e7d082f5fb466e3a84733855295fa7aafd1b31b7d8"
 dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "1.3.16"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
+checksum = "eec1cd5469f328c782dc3e33d4153cf118a54e33cbb3356d60d16f89883e1f94"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -534,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -549,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -564,9 +575,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bytes-utils"
@@ -580,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -598,9 +609,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -618,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -630,14 +641,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -669,9 +680,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -801,7 +812,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -812,7 +823,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -826,9 +837,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "derive_builder"
@@ -848,7 +856,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -858,7 +866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -887,7 +895,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid",
  "crypto-common 0.2.2",
  "ctutils",
@@ -901,7 +909,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -940,9 +948,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -955,12 +963,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -985,41 +987,41 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-timer"
@@ -1029,9 +1031,9 @@ checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-macro",
@@ -1063,47 +1065,33 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
- "wasip2",
- "wasip3",
+ "r-efi",
 ]
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.1",
+ "http 1.4.2",
  "indexmap",
  "slab",
  "tokio",
@@ -1113,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "6.4.1"
+version = "6.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d43ccdfe15a81ab0a8af639e90254227c9a46afd9c5f5b6ec7efaa345c4b0f00"
+checksum = "4633d16a2350341713c379d6d06a4b9e1845329386026a49ce4fd09c2f3b16f6"
 dependencies = [
  "derive_builder",
  "log",
@@ -1129,22 +1117,13 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -1187,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1208,24 +1187,24 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
- "http 1.4.1",
+ "http 1.4.2",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.1",
- "http-body 1.0.1",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "pin-project-lite",
 ]
 
@@ -1237,26 +1216,26 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.1",
- "http-body 1.0.1",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1271,7 +1250,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.1",
+ "http 1.4.2",
  "hyper",
  "hyper-util",
  "rustls",
@@ -1291,8 +1270,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.1",
- "http-body 1.0.1",
+ "http 1.4.2",
+ "http-body 1.1.0",
  "hyper",
  "ipnet",
  "libc",
@@ -1387,12 +1366,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,9 +1394,9 @@ dependencies = [
 
 [[package]]
 name = "include-flate"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e233413926ef735f7d87024466cfda5a4b87467730846bd82ea7d504121347"
+checksum = "48f173716febb1ad596c16ea5637b5f1790ea32de8e627493ff82bc73b0876ce"
 dependencies = [
  "include-flate-codegen",
  "include-flate-compress",
@@ -1431,22 +1404,22 @@ dependencies = [
 
 [[package]]
 name = "include-flate-codegen"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e7148f24ef8922cc0e5574ebb908729ccdd3a110c440a45165733fedadd9969"
+checksum = "4a7875b62a72ad3f3203cdd8950d4cf9947db036030b974b8b37ceae90c8d8c0"
 dependencies = [
  "include-flate-compress",
- "proc-macro-error2",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "include-flate-compress"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74783a9ed407e844e99d5e7a57bd650acbfa124cf6e97ffd790ba59d8ab8e7ff"
+checksum = "44fbb9c5ccb9a5b67b4afa2974c27e5507ea1bf6d22828cef418e4dfaeca51dd"
 dependencies = [
  "libflate",
  "zstd",
@@ -1460,15 +1433,13 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
 name = "insta"
-version = "1.47.2"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
  "console",
  "once_cell",
@@ -1496,23 +1467,22 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1523,16 +1493,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libflate"
@@ -1572,21 +1536,37 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -1628,9 +1608,9 @@ dependencies = [
 
 [[package]]
 name = "num-modular"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
+checksum = "fc41a1374056e9672221567958a66c16be12d0e2c1b408761e14d901c237d5e0"
 
 [[package]]
 name = "num-order"
@@ -1682,9 +1662,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -1692,9 +1672,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1702,25 +1682,24 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1757,16 +1736,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1776,50 +1745,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
+name = "proc-macro-error-attr3"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+checksum = "34e4dd828515431dd6c4a030d26f7eaed7dd4778226e9d2bb968d65ca4ec3d4d"
 dependencies = [
  "proc-macro2",
  "quote",
 ]
 
 [[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
+name = "proc-macro-error3"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+checksum = "5ee475e440453418ff1335189eddf7101ba502cd818ab7ae04209bc83aa925aa"
 dependencies = [
- "proc-macro-error-attr2",
+ "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1829,9 +1792,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1841,9 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1858,9 +1821,9 @@ checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "relative-path"
@@ -1913,15 +1876,15 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn",
+ "syn 2.0.119",
  "unicode-ident",
 ]
 
 [[package]]
 name = "rust-embed"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
 dependencies = [
  "include-flate",
  "rust-embed-impl",
@@ -1931,24 +1894,26 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
 dependencies = [
+ "mime_guess",
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn",
+ "syn 2.0.119",
  "walkdir",
 ]
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.11.0"
+version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
 dependencies = [
- "sha2 0.10.9",
+ "include-flate",
+ "sha2",
  "walkdir",
 ]
 
@@ -1976,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -2002,9 +1967,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "zeroize",
 ]
@@ -2023,9 +1988,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -2082,9 +2047,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -2092,30 +2057,31 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -2138,20 +2104,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -2214,15 +2169,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2255,7 +2210,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2266,9 +2221,20 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2283,7 +2249,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2293,7 +2259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2301,38 +2267,38 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "num-conv",
@@ -2344,15 +2310,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2370,9 +2336,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -2386,13 +2352,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2407,13 +2373,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -2429,9 +2396,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2490,7 +2457,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2545,6 +2512,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2555,12 +2528,6 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -2606,9 +2573,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2658,28 +2625,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2690,9 +2639,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2700,58 +2649,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -2853,105 +2768,11 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
 ]
 
 [[package]]
@@ -2984,9 +2805,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3001,7 +2822,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -3022,15 +2843,15 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
@@ -3062,14 +2883,14 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"

--- a/clusters/al2023-arm64/eks.tf
+++ b/clusters/al2023-arm64/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "al2023-arm64"
   kubernetes_version = "1.34"

--- a/clusters/al2023-arm64/main.tf
+++ b/clusters/al2023-arm64/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
   }
 }

--- a/clusters/al2023-instance-storage/eks.tf
+++ b/clusters/al2023-instance-storage/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "al2023-instance-storage"
   kubernetes_version = "1.34"

--- a/clusters/al2023-instance-storage/main.tf
+++ b/clusters/al2023-instance-storage/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
   }
 }

--- a/clusters/al2023-x86-64/eks.tf
+++ b/clusters/al2023-x86-64/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "al2023-x86-64"
   kubernetes_version = "1.34"

--- a/clusters/al2023-x86-64/main.tf
+++ b/clusters/al2023-x86-64/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
   }
 }

--- a/clusters/auto-mode/eks.tf
+++ b/clusters/auto-mode/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "auto-mode"
   kubernetes_version = "1.34"

--- a/clusters/auto-mode/main.tf
+++ b/clusters/auto-mode/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
   }
 }

--- a/clusters/bottlerocket-arm64/eks.tf
+++ b/clusters/bottlerocket-arm64/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "bottlerocket-arm64"
   kubernetes_version = "1.34"

--- a/clusters/bottlerocket-arm64/main.tf
+++ b/clusters/bottlerocket-arm64/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
   }
 }

--- a/clusters/bottlerocket-x86-64/eks.tf
+++ b/clusters/bottlerocket-x86-64/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "bottlerocket-x86-64"
   kubernetes_version = "1.34"

--- a/clusters/bottlerocket-x86-64/main.tf
+++ b/clusters/bottlerocket-x86-64/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
   }
 }

--- a/clusters/default/eks.tf
+++ b/clusters/default/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/clusters/default/main.tf
+++ b/clusters/default/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
   }
 }

--- a/clusters/enable-all/eks.tf
+++ b/clusters/enable-all/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "enable-all"
   kubernetes_version = "1.34"

--- a/clusters/enable-all/main.tf
+++ b/clusters/enable-all/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
   }
 }

--- a/clusters/karpenter/eks.tf
+++ b/clusters/karpenter/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "karpenter"
   kubernetes_version = "1.34"

--- a/clusters/karpenter/helm.tf
+++ b/clusters/karpenter/helm.tf
@@ -4,7 +4,7 @@
 
 module "karpenter" {
   source  = "terraform-aws-modules/eks/aws//modules/karpenter"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   cluster_name = module.eks.cluster_name
 
@@ -27,7 +27,7 @@ resource "helm_release" "karpenter" {
   namespace  = "kube-system"
   repository = "oci://public.ecr.aws/karpenter"
   chart      = "karpenter"
-  version    = "1.8.3"
+  version    = "1.14.0"
   wait       = false
 
   values = [

--- a/clusters/karpenter/main.tf
+++ b/clusters/karpenter/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.1"
+      version = ">= 3.2"
     }
   }
 }

--- a/clusters/neuron-efa-cbr/eks.tf
+++ b/clusters/neuron-efa-cbr/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "neuron-efa-cbr"
   kubernetes_version = "1.34"

--- a/clusters/neuron-efa-cbr/helm.tf
+++ b/clusters/neuron-efa-cbr/helm.tf
@@ -6,7 +6,7 @@ resource "helm_release" "neuron" {
   name             = "neuron"
   repository       = "oci://public.ecr.aws/neuron"
   chart            = "neuron-helm-chart"
-  version          = "1.4.0"
+  version          = "1.9.0"
   namespace        = "neuron"
   create_namespace = true
   wait             = false
@@ -26,7 +26,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.20"
+  version    = "v0.5.29"
   wait       = false
 
   values = [

--- a/clusters/neuron-efa-cbr/main.tf
+++ b/clusters/neuron-efa-cbr/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.1"
+      version = ">= 3.2"
     }
   }
 }

--- a/clusters/neuron-efa/eks.tf
+++ b/clusters/neuron-efa/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "neuron-efa"
   kubernetes_version = "1.34"

--- a/clusters/neuron-efa/helm.tf
+++ b/clusters/neuron-efa/helm.tf
@@ -6,7 +6,7 @@ resource "helm_release" "neuron" {
   name             = "neuron"
   repository       = "oci://public.ecr.aws/neuron"
   chart            = "neuron-helm-chart"
-  version          = "1.4.0"
+  version          = "1.9.0"
   namespace        = "neuron"
   create_namespace = true
   wait             = false
@@ -26,7 +26,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.20"
+  version    = "v0.5.29"
   wait       = false
 
   values = [

--- a/clusters/neuron-efa/main.tf
+++ b/clusters/neuron-efa/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.1"
+      version = ">= 3.2"
     }
   }
 }

--- a/clusters/neuron/eks.tf
+++ b/clusters/neuron/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "neuron"
   kubernetes_version = "1.34"

--- a/clusters/neuron/helm.tf
+++ b/clusters/neuron/helm.tf
@@ -6,7 +6,7 @@ resource "helm_release" "neuron" {
   name             = "neuron"
   repository       = "oci://public.ecr.aws/neuron"
   chart            = "neuron-helm-chart"
-  version          = "1.4.0"
+  version          = "1.9.0"
   namespace        = "neuron"
   create_namespace = true
   wait             = false

--- a/clusters/neuron/main.tf
+++ b/clusters/neuron/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.1"
+      version = ">= 3.2"
     }
   }
 }

--- a/clusters/nvidia-cbr/eks.tf
+++ b/clusters/nvidia-cbr/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "nvidia-cbr"
   kubernetes_version = "1.34"

--- a/clusters/nvidia-cbr/helm.tf
+++ b/clusters/nvidia-cbr/helm.tf
@@ -6,7 +6,7 @@ resource "helm_release" "nvidia_device_plugin" {
   name             = "nvidia-device-plugin"
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
-  version          = "0.18.1"
+  version          = "0.19.3"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false

--- a/clusters/nvidia-cbr/main.tf
+++ b/clusters/nvidia-cbr/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.1"
+      version = ">= 3.2"
     }
   }
 }

--- a/clusters/nvidia-efa-cbr/eks.tf
+++ b/clusters/nvidia-efa-cbr/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "nvidia-efa-cbr"
   kubernetes_version = "1.34"

--- a/clusters/nvidia-efa-cbr/helm.tf
+++ b/clusters/nvidia-efa-cbr/helm.tf
@@ -6,7 +6,7 @@ resource "helm_release" "nvidia_device_plugin" {
   name             = "nvidia-device-plugin"
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
-  version          = "0.18.1"
+  version          = "0.19.3"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false
@@ -17,7 +17,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.20"
+  version    = "v0.5.29"
   wait       = false
 
   values = [

--- a/clusters/nvidia-efa-cbr/main.tf
+++ b/clusters/nvidia-efa-cbr/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.1"
+      version = ">= 3.2"
     }
   }
 }

--- a/clusters/nvidia-efa-odcr/eks.tf
+++ b/clusters/nvidia-efa-odcr/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "nvidia-efa-odcr"
   kubernetes_version = "1.34"

--- a/clusters/nvidia-efa-odcr/helm.tf
+++ b/clusters/nvidia-efa-odcr/helm.tf
@@ -6,7 +6,7 @@ resource "helm_release" "nvidia_device_plugin" {
   name             = "nvidia-device-plugin"
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
-  version          = "0.18.1"
+  version          = "0.19.3"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false
@@ -17,7 +17,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.20"
+  version    = "v0.5.29"
   wait       = false
 
   values = [

--- a/clusters/nvidia-efa-odcr/main.tf
+++ b/clusters/nvidia-efa-odcr/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.1"
+      version = ">= 3.2"
     }
   }
 }

--- a/clusters/nvidia-efa/eks.tf
+++ b/clusters/nvidia-efa/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "nvidia-efa"
   kubernetes_version = "1.34"

--- a/clusters/nvidia-efa/helm.tf
+++ b/clusters/nvidia-efa/helm.tf
@@ -6,7 +6,7 @@ resource "helm_release" "nvidia_device_plugin" {
   name             = "nvidia-device-plugin"
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
-  version          = "0.18.1"
+  version          = "0.19.3"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false
@@ -17,7 +17,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.20"
+  version    = "v0.5.29"
   wait       = false
 
   values = [

--- a/clusters/nvidia-efa/main.tf
+++ b/clusters/nvidia-efa/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.1"
+      version = ">= 3.2"
     }
   }
 }

--- a/clusters/nvidia/eks.tf
+++ b/clusters/nvidia/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "nvidia"
   kubernetes_version = "1.34"

--- a/clusters/nvidia/helm.tf
+++ b/clusters/nvidia/helm.tf
@@ -6,7 +6,7 @@ resource "helm_release" "nvidia_device_plugin" {
   name             = "nvidia-device-plugin"
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
-  version          = "0.18.1"
+  version          = "0.19.3"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false

--- a/clusters/nvidia/main.tf
+++ b/clusters/nvidia/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.1"
+      version = ">= 3.2"
     }
   }
 }

--- a/cookiecluster/Cargo.toml
+++ b/cookiecluster/Cargo.toml
@@ -18,7 +18,7 @@ clap = { version = "4.6", features = ["derive", "color"] }
 clap-verbosity-flag = "3.0"
 dialoguer = { version = "0.12", default-features = false }
 handlebars =  "6.4"
-rust-embed = { version = "8.11", features = ["compression"] }
+rust-embed = { version = "8.12", features = ["compression"] }
 serde.workspace = true
 serde_json = "1.0"
 serde_yaml_ng = "0.10"
@@ -29,7 +29,7 @@ tracing-log.workspace = true
 tracing-subscriber.workspace = true
 
 [dev-dependencies]
-insta = "1.47"
+insta = "1.48"
 rstest = "0.26"
 tempfile = "3"
 

--- a/cookiecluster/src/snapshots/al2023-arm64/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/al2023-arm64/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/al2023-arm64/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/al2023-arm64/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
   }
 }

--- a/cookiecluster/src/snapshots/al2023-instance-storage/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/al2023-instance-storage/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/al2023-instance-storage/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/al2023-instance-storage/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
   }
 }

--- a/cookiecluster/src/snapshots/al2023-x86-64/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/al2023-x86-64/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/al2023-x86-64/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/al2023-x86-64/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
   }
 }

--- a/cookiecluster/src/snapshots/all-add-ons/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/all-add-ons/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"
@@ -100,7 +100,7 @@ module "eks" {
 
 module "amazon_cloudwatch_observability_pod_identity" {
   source = "terraform-aws-modules/eks-pod-identity/aws"
-  version = "~> 2.7"
+  version = "~> 2.8"
 
   name = "aws-cloudwatch-observability"
 
@@ -111,7 +111,7 @@ module "amazon_cloudwatch_observability_pod_identity" {
 
 module "aws_ebs_csi_driver_pod_identity" {
   source = "terraform-aws-modules/eks-pod-identity/aws"
-  version = "~> 2.7"
+  version = "~> 2.8"
 
   name = "aws-ebs-csi"
 
@@ -122,7 +122,7 @@ module "aws_ebs_csi_driver_pod_identity" {
 
 module "aws_efs_csi_driver_pod_identity" {
   source = "terraform-aws-modules/eks-pod-identity/aws"
-  version = "~> 2.7"
+  version = "~> 2.8"
 
   name = "aws-efs-csi"
 
@@ -133,7 +133,7 @@ module "aws_efs_csi_driver_pod_identity" {
 
 module "aws_mountpoint_s3_csi_driver_pod_identity" {
   source = "terraform-aws-modules/eks-pod-identity/aws"
-  version = "~> 2.7"
+  version = "~> 2.8"
 
   name = "mountpoint-s3-csi"
 

--- a/cookiecluster/src/snapshots/all-add-ons/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/all-add-ons/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
   }
 }

--- a/cookiecluster/src/snapshots/auto-mode-efa/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/auto-mode-efa/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/auto-mode-efa/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/auto-mode-efa/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
   }
 }

--- a/cookiecluster/src/snapshots/auto-mode-neuron/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/auto-mode-neuron/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/auto-mode-neuron/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/auto-mode-neuron/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
   }
 }

--- a/cookiecluster/src/snapshots/auto-mode-nvidia/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/auto-mode-nvidia/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/auto-mode-nvidia/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/auto-mode-nvidia/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
   }
 }

--- a/cookiecluster/src/snapshots/auto-mode/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/auto-mode/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/auto-mode/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/auto-mode/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
   }
 }

--- a/cookiecluster/src/snapshots/bottlerocket-arm64/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/bottlerocket-arm64/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/bottlerocket-arm64/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/bottlerocket-arm64/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
   }
 }

--- a/cookiecluster/src/snapshots/bottlerocket-nvidia/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/bottlerocket-nvidia/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/bottlerocket-nvidia/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/bottlerocket-nvidia/cookiecluster__cli__tests__helm.snap
@@ -11,7 +11,7 @@ resource "helm_release" "nvidia_device_plugin" {
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
   # Update to the latest compatible version: https://github.com/NVIDIA/k8s-device-plugin/releases
-  version          = "0.18.1"
+  version          = "0.19.3"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false

--- a/cookiecluster/src/snapshots/bottlerocket-nvidia/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/bottlerocket-nvidia/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.1"
+      version = ">= 3.2"
     }
   }
 }

--- a/cookiecluster/src/snapshots/bottlerocket-x86-64/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/bottlerocket-x86-64/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/bottlerocket-x86-64/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/bottlerocket-x86-64/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
   }
 }

--- a/cookiecluster/src/snapshots/cluster-autoscaler/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/cluster-autoscaler/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/cluster-autoscaler/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/cluster-autoscaler/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
   }
 }

--- a/cookiecluster/src/snapshots/default/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/default/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/default/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/default/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
   }
 }

--- a/cookiecluster/src/snapshots/enable-all/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/enable-all/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "cookiecluster"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/enable-all/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/enable-all/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
   }
 }

--- a/cookiecluster/src/snapshots/karpenter-odcr/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/karpenter-odcr/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/karpenter-odcr/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/karpenter-odcr/cookiecluster__cli__tests__helm.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "karpenter" {
   source  = "terraform-aws-modules/eks/aws//modules/karpenter"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   cluster_name = module.eks.cluster_name
 
@@ -32,7 +32,7 @@ resource "helm_release" "karpenter" {
   repository = "oci://public.ecr.aws/karpenter"
   chart      = "karpenter"
   # Update to the latest compatible version: https://github.com/aws/karpenter-provider-aws/releases
-  version    = "1.8.3"
+  version    = "1.14.0"
   wait       = false
 
   values = [
@@ -57,7 +57,7 @@ resource "helm_release" "nvidia_device_plugin" {
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
   # Update to the latest compatible version: https://github.com/NVIDIA/k8s-device-plugin/releases
-  version          = "0.18.1"
+  version          = "0.19.3"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false

--- a/cookiecluster/src/snapshots/karpenter-odcr/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/karpenter-odcr/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.1"
+      version = ">= 3.2"
     }
   }
 }

--- a/cookiecluster/src/snapshots/karpenter/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/karpenter/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/karpenter/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/karpenter/cookiecluster__cli__tests__helm.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "karpenter" {
   source  = "terraform-aws-modules/eks/aws//modules/karpenter"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   cluster_name = module.eks.cluster_name
 
@@ -32,7 +32,7 @@ resource "helm_release" "karpenter" {
   repository = "oci://public.ecr.aws/karpenter"
   chart      = "karpenter"
   # Update to the latest compatible version: https://github.com/aws/karpenter-provider-aws/releases
-  version    = "1.8.3"
+  version    = "1.14.0"
   wait       = false
 
   values = [

--- a/cookiecluster/src/snapshots/karpenter/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/karpenter/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.1"
+      version = ">= 3.2"
     }
   }
 }

--- a/cookiecluster/src/snapshots/neuron-cbr/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/neuron-cbr/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/neuron-cbr/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/neuron-cbr/cookiecluster__cli__tests__helm.snap
@@ -11,7 +11,7 @@ resource "helm_release" "neuron" {
   repository       = "oci://public.ecr.aws/neuron"
   chart            = "neuron-helm-chart"
   # Update to the latest compatible version: https://github.com/aws-neuron/neuron-helm-charts
-  version          = "1.4.0"
+  version          = "1.9.0"
   namespace        = "neuron"
   create_namespace = true
   wait             = false
@@ -31,7 +31,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.20"
+  version    = "v0.5.29"
   wait       = false
 
   values = [

--- a/cookiecluster/src/snapshots/neuron-cbr/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/neuron-cbr/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.1"
+      version = ">= 3.2"
     }
   }
 }

--- a/cookiecluster/src/snapshots/neuron-efa/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/neuron-efa/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/neuron-efa/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/neuron-efa/cookiecluster__cli__tests__helm.snap
@@ -11,7 +11,7 @@ resource "helm_release" "neuron" {
   repository       = "oci://public.ecr.aws/neuron"
   chart            = "neuron-helm-chart"
   # Update to the latest compatible version: https://github.com/aws-neuron/neuron-helm-charts
-  version          = "1.4.0"
+  version          = "1.9.0"
   namespace        = "neuron"
   create_namespace = true
   wait             = false
@@ -31,7 +31,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.20"
+  version    = "v0.5.29"
   wait       = false
 
   values = [

--- a/cookiecluster/src/snapshots/neuron-efa/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/neuron-efa/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.1"
+      version = ">= 3.2"
     }
   }
 }

--- a/cookiecluster/src/snapshots/neuron-odcr/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/neuron-odcr/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/neuron-odcr/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/neuron-odcr/cookiecluster__cli__tests__helm.snap
@@ -11,7 +11,7 @@ resource "helm_release" "neuron" {
   repository       = "oci://public.ecr.aws/neuron"
   chart            = "neuron-helm-chart"
   # Update to the latest compatible version: https://github.com/aws-neuron/neuron-helm-charts
-  version          = "1.4.0"
+  version          = "1.9.0"
   namespace        = "neuron"
   create_namespace = true
   wait             = false
@@ -31,7 +31,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.20"
+  version    = "v0.5.29"
   wait       = false
 
   values = [

--- a/cookiecluster/src/snapshots/neuron-odcr/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/neuron-odcr/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.1"
+      version = ">= 3.2"
     }
   }
 }

--- a/cookiecluster/src/snapshots/neuron/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/neuron/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/neuron/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/neuron/cookiecluster__cli__tests__helm.snap
@@ -11,7 +11,7 @@ resource "helm_release" "neuron" {
   repository       = "oci://public.ecr.aws/neuron"
   chart            = "neuron-helm-chart"
   # Update to the latest compatible version: https://github.com/aws-neuron/neuron-helm-charts
-  version          = "1.4.0"
+  version          = "1.9.0"
   namespace        = "neuron"
   create_namespace = true
   wait             = false

--- a/cookiecluster/src/snapshots/neuron/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/neuron/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.1"
+      version = ">= 3.2"
     }
   }
 }

--- a/cookiecluster/src/snapshots/nvidia-cbr/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/nvidia-cbr/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/nvidia-cbr/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/nvidia-cbr/cookiecluster__cli__tests__helm.snap
@@ -11,7 +11,7 @@ resource "helm_release" "nvidia_device_plugin" {
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
   # Update to the latest compatible version: https://github.com/NVIDIA/k8s-device-plugin/releases
-  version          = "0.18.1"
+  version          = "0.19.3"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false

--- a/cookiecluster/src/snapshots/nvidia-cbr/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/nvidia-cbr/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.1"
+      version = ">= 3.2"
     }
   }
 }

--- a/cookiecluster/src/snapshots/nvidia-efa-cbr/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/nvidia-efa-cbr/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/nvidia-efa-cbr/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/nvidia-efa-cbr/cookiecluster__cli__tests__helm.snap
@@ -11,7 +11,7 @@ resource "helm_release" "nvidia_device_plugin" {
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
   # Update to the latest compatible version: https://github.com/NVIDIA/k8s-device-plugin/releases
-  version          = "0.18.1"
+  version          = "0.19.3"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false
@@ -22,7 +22,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.20"
+  version    = "v0.5.29"
   wait       = false
 
   values = [

--- a/cookiecluster/src/snapshots/nvidia-efa-cbr/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/nvidia-efa-cbr/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.1"
+      version = ">= 3.2"
     }
   }
 }

--- a/cookiecluster/src/snapshots/nvidia-efa-odcr/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/nvidia-efa-odcr/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/nvidia-efa-odcr/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/nvidia-efa-odcr/cookiecluster__cli__tests__helm.snap
@@ -11,7 +11,7 @@ resource "helm_release" "nvidia_device_plugin" {
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
   # Update to the latest compatible version: https://github.com/NVIDIA/k8s-device-plugin/releases
-  version          = "0.18.1"
+  version          = "0.19.3"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false
@@ -22,7 +22,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.20"
+  version    = "v0.5.29"
   wait       = false
 
   values = [

--- a/cookiecluster/src/snapshots/nvidia-efa-odcr/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/nvidia-efa-odcr/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.1"
+      version = ">= 3.2"
     }
   }
 }

--- a/cookiecluster/src/snapshots/nvidia-no-efa/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/nvidia-no-efa/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/nvidia-no-efa/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/nvidia-no-efa/cookiecluster__cli__tests__helm.snap
@@ -11,7 +11,7 @@ resource "helm_release" "nvidia_device_plugin" {
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
   # Update to the latest compatible version: https://github.com/NVIDIA/k8s-device-plugin/releases
-  version          = "0.18.1"
+  version          = "0.19.3"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false

--- a/cookiecluster/src/snapshots/nvidia-no-efa/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/nvidia-no-efa/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.1"
+      version = ">= 3.2"
     }
   }
 }

--- a/cookiecluster/src/snapshots/nvidia/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/nvidia/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/nvidia/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/nvidia/cookiecluster__cli__tests__helm.snap
@@ -11,7 +11,7 @@ resource "helm_release" "nvidia_device_plugin" {
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
   # Update to the latest compatible version: https://github.com/NVIDIA/k8s-device-plugin/releases
-  version          = "0.18.1"
+  version          = "0.19.3"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false

--- a/cookiecluster/src/snapshots/nvidia/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/nvidia/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.1"
+      version = ">= 3.2"
     }
   }
 }

--- a/cookiecluster/src/snapshots/nvidia_efa/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/nvidia_efa/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/nvidia_efa/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/nvidia_efa/cookiecluster__cli__tests__helm.snap
@@ -11,7 +11,7 @@ resource "helm_release" "nvidia_device_plugin" {
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
   # Update to the latest compatible version: https://github.com/NVIDIA/k8s-device-plugin/releases
-  version          = "0.18.1"
+  version          = "0.19.3"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false
@@ -22,7 +22,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.20"
+  version    = "v0.5.29"
   wait       = false
 
   values = [

--- a/cookiecluster/src/snapshots/nvidia_efa/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/nvidia_efa/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.1"
+      version = ">= 3.2"
     }
   }
 }

--- a/cookiecluster/templates/eks.tpl
+++ b/cookiecluster/templates/eks.tpl
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   name               = "{{ inputs.name }}"
   kubernetes_version = "{{ inputs.kubernetes_version }}"

--- a/cookiecluster/templates/helm.tpl
+++ b/cookiecluster/templates/helm.tpl
@@ -6,7 +6,7 @@
 
 module "karpenter" {
   source  = "terraform-aws-modules/eks/aws//modules/karpenter"
-  version = "~> 21.14"
+  version = "~> 21.24"
 
   cluster_name = module.eks.cluster_name
 
@@ -30,7 +30,7 @@ resource "helm_release" "karpenter" {
   repository = "oci://public.ecr.aws/karpenter"
   chart      = "karpenter"
   # Update to the latest compatible version: https://github.com/aws/karpenter-provider-aws/releases
-  version    = "1.8.3"
+  version    = "1.14.0"
   wait       = false
 
   values = [
@@ -57,7 +57,7 @@ resource "helm_release" "nvidia_device_plugin" {
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
   # Update to the latest compatible version: https://github.com/NVIDIA/k8s-device-plugin/releases
-  version          = "0.18.1"
+  version          = "0.19.3"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false
@@ -70,7 +70,7 @@ resource "helm_release" "neuron" {
   repository       = "oci://public.ecr.aws/neuron"
   chart            = "neuron-helm-chart"
   # Update to the latest compatible version: https://github.com/aws-neuron/neuron-helm-charts
-  version          = "1.4.0"
+  version          = "1.9.0"
   namespace        = "neuron"
   create_namespace = true
   wait             = false
@@ -92,7 +92,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.20"
+  version    = "v0.5.29"
   wait       = false
 
   values = [

--- a/cookiecluster/templates/main.tpl
+++ b/cookiecluster/templates/main.tpl
@@ -4,12 +4,12 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = ">= 6.55"
     }
     {{ #if inputs.enable_helm }}
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.1"
+      version = ">= 3.2"
     }
     {{ /if }}
   }

--- a/cookiecluster/templates/pod-identity.tpl
+++ b/cookiecluster/templates/pod-identity.tpl
@@ -6,7 +6,7 @@
 {{ #if a.configuration.pod_identity_role_arn }}
 module "{{ snake_case a.name }}_pod_identity" {
   source = "terraform-aws-modules/eks-pod-identity/aws"
-  version = "~> 2.7"
+  version = "~> 2.8"
 
   {{ #if (eq a.name "aws-ebs-csi-driver") }}
   name = "aws-ebs-csi"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,12 +10,12 @@ edition.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-aws-config = {version="1.8", features=["behavior-version-latest"]}
-aws-types = "1.3"
-aws-sdk-ec2 = { version = "1.229", default-features = false, features = ["default-https-client", "rt-tokio"] }
+aws-config = {version="1.10", features=["behavior-version-latest"]}
+aws-types = "1.5"
+aws-sdk-ec2 = { version = "1.241", default-features = false, features = ["default-https-client", "rt-tokio"] }
 handlebars = "6.4"
 serde.workspace = true
 serde_json = "1.0"
-tokio = { version = "1.52", default-features = false, features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.53", default-features = false, features = ["macros", "rt-multi-thread"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true


### PR DESCRIPTION
Bumps every dependency to latest across Rust, GitHub Actions, pre-commit, and the Terraform module, provider, and chart versions embedded in the generation templates, all within the current major except the two CI actions.

- rust-embed 8.11 → 8.12
- insta 1.47 → 1.48
- aws-config 1.8 → 1.10
- aws-types 1.3 → 1.5
- aws-sdk-ec2 1.229 → 1.241
- tokio 1.52 → 1.53
- actions/checkout 6.0.3 → 7.0.1
- actions/cache 5.0.5 → 6.1.0
- dtolnay/rust-toolchain → latest master
- antonbabenko/pre-commit-terraform 1.105.0 → 1.108.0
- terraform-aws-modules/eks/aws ~> 21.14 → ~> 21.24
- terraform-aws-modules/eks-pod-identity/aws ~> 2.7 → ~> 2.8
- hashicorp/aws >= 6.28 → >= 6.55
- hashicorp/helm >= 3.1 → >= 3.2
- karpenter chart 1.8.3 → 1.14.0
- nvidia-device-plugin chart 0.18.1 → 0.19.3
- neuron-helm-chart 1.4.0 → 1.9.0
- aws-efa-k8s-device-plugin chart v0.5.20 → v0.5.29

The Terraform versions live in cookiecluster/templates/*.tpl. Bumping them regenerates the insta snapshots under cookiecluster/src/snapshots/, and the matching version pins in the committed clusters/ examples were updated in place to keep them consistent. The generated configs were checked with terraform init and validate against the new module and provider versions, covering karpenter, auto-mode, nvidia-efa, neuron-efa, and enable-all. The helm chart versions come from the upstream registries and their values blocks are not schema-validated by terraform validate.

Supersedes #89, #86.
