### PR TITLE
Cut dev-profile debuginfo to line tables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,12 @@ tracing = { version = "0.1", default-features = false, features = ["log-always"]
 tracing-log = "0.2"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "std", "ansi"] }
 
+[profile.dev]
+# Cargo defaults to full debuginfo, the largest single component of target/.
+# Line tables keep backtraces readable while dropping the variable and type
+# information a debugger would use.
+debug = "line-tables-only"
+
 [profile.release]
 strip = true
 lto = true


### PR DESCRIPTION
Cargo defaults to full debuginfo, the largest single component of a `target/` directory. Line tables keep backtraces readable while dropping the variable and type information a debugger would use.

Measured on `terraform-provider-lambdabuild`, a complete `--all-targets` build drops from 5.6 GiB to 4.3 GiB.

**Tradeoff:** backtraces still work; stepping through with variable and type inspection degrades.

Close-out not run: config-only diff, no Rust source changed.