### PR TITLE
chore(deps): update all dependencies to latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # nightly
+        uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # nightly
         with:
           toolchain: nightly
           components: rustfmt
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # nightly
+        uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # nightly
         with:
           toolchain: nightly
           components: clippy
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # nightly
+        uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # nightly
         with:
           toolchain: nightly
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
           echo "version is: ${COOKIECLUSTER_VERSION}"
 
       - name: Generate a changelog
-        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
+        uses: orhun/git-cliff-action@3d96a18cc4ec17e9dc69ddcc424ccafaf1f78ce2 # v4.9.0
         id: git-cliff
         with:
           config: cliff.toml
@@ -84,7 +84,7 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+      uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
       with:
         toolchain: ${{ matrix.rust }}
         target: ${{ matrix.target }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,3 @@
-exclude: ^cookiecluster/src/snapshots/
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.109.1
@@ -8,7 +7,13 @@ repos:
     rev: v6.0.0
     hooks:
       - id: check-merge-conflict
+      # The insta snapshots are byte-exact fixtures of rendered Terraform, and the
+      # rendered output carries trailing whitespace. Rewriting it here would break
+      # every snapshot assertion.
       - id: end-of-file-fixer
+        exclude: ^cookiecluster/src/snapshots/
       - id: trailing-whitespace
+        exclude: ^cookiecluster/src/snapshots/
       - id: mixed-line-ending
         args: [--fix=lf]
+        exclude: ^cookiecluster/src/snapshots/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
+exclude: ^cookiecluster/src/snapshots/
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.108.0
+    rev: v1.109.1
     hooks:
       - id: terraform_fmt
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -102,9 +102,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a767267da9e2c2e189b2f9df8b5657e850ecf5352644734ba130d4a57095cf1b"
+checksum = "b8d7b388a9fc3a6db15a5ec778c38b354eff1364882c94d08e0252f7a47dcaa4"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -122,7 +122,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "http 1.4.2",
+ "http 1.5.0",
  "sha1",
  "time",
  "tokio",
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.3"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.43.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
 dependencies = [
  "cc",
  "cmake",
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9007227e10b5fed2f3e0a2beff489211e2b5604c400b7a9d5d81ca9d64c24bb"
+checksum = "ef47857a1d4488b528f4a5d5715fa7c3300820897824152234d3fa22b1426657"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -183,7 +183,7 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "fastrand",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "percent-encoding",
  "pin-project-lite",
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ec2"
-version = "1.248.0"
+version = "1.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1466434bbf91bacd352a31d4e960f0ed3169e01b225a8921923a3577aa68300b"
+checksum = "041b4dd0bcfdec237d450fc9f1ee620296db9b32c4f674381a6183dde1fab8fb"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -213,16 +213,16 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.107.0"
+version = "1.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0abd0f89cfe11da5099986dd493e4f94347ce9a4562cb86ddecfe926b6c0"
+checksum = "c3cfe74df5d9ad2fedd691973ad3521ebf4f27a3c68c792556686aedb5519bab"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -239,16 +239,16 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.109.0"
+version = "1.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4075b8a2c8cda4076a3dcc43b9d6dabd93e0c2502abeaaf7e14aaead9bb312b"
+checksum = "81b0ec31ed6191bd11350aae4b2004198f2db21350cb0a20c57e0a92e55dd161"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -265,16 +265,16 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.112.0"
+version = "1.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f582002918346a3e685be1b391c7bea155073088cea6bd4e4b7663df9e43b6c"
+checksum = "ef45745026107ec30c4ef86bd8ae4b002e7e5f6a86e4225240bdf6b06a0b944a"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -292,7 +292,7 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
@@ -312,7 +312,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "percent-encoding",
  "sha2",
  "time",
@@ -342,7 +342,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "percent-encoding",
@@ -361,7 +361,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2",
- "http 1.4.2",
+ "http 1.5.0",
  "hyper",
  "hyper-rustls",
  "hyper-util",
@@ -424,7 +424,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 0.4.6",
  "http-body 1.1.0",
  "http-body-util",
@@ -436,16 +436,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954c563ce84507722d2679f07a35d21b9c6466b3872d513020d0281fc8112ac9"
+checksum = "9c054752dd9e4dc73d0b75748c99ac2d0feafbf2f25c7b0516f03a3534161223"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -471,21 +471,21 @@ checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http 1.4.2",
+ "http 1.5.0",
 ]
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.6.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce83ce9abbb198d25bc7131e468d0f9fe1257125e58c39f3f9fc9f5098c9647"
+checksum = "8f94d16e797ec62cd999fc9d5942b48fa7050c3093ddadff48e4d7528d16fcb9"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 0.4.6",
  "http-body 1.1.0",
  "http-body-util",
@@ -514,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec1cd5469f328c782dc3e33d4153cf118a54e33cbb3356d60d16f89883e1f94"
+checksum = "209f3a6d82a6e9e5f94abbed94c7a26e1c052341002bf57a5fb5481f625896fc"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -591,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -648,7 +648,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -747,18 +747,18 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -903,13 +903,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -920,9 +920,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "encode_unicode"
@@ -954,9 +954,9 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "fnv"
@@ -987,41 +987,41 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-timer"
@@ -1031,9 +1031,9 @@ checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-core",
  "futures-macro",
@@ -1082,16 +1082,16 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.2",
+ "http 1.5.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1166,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1192,18 +1192,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
- "http 1.4.2",
+ "http 1.5.0",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "pin-project-lite",
 ]
@@ -1216,25 +1216,25 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "httparse",
  "itoa",
@@ -1250,7 +1250,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.2",
+ "http 1.5.0",
  "hyper",
  "hyper-util",
  "rustls",
@@ -1270,7 +1270,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "hyper",
  "ipnet",
@@ -1285,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1299,9 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1312,9 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1326,16 +1326,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -1346,15 +1347,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1427,9 +1428,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -1449,9 +1450,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1477,9 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1500,9 +1501,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libflate"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd96e993e5f3368b0cb8497dae6c860c22af8ff18388c61c6c0b86c58d86b5df"
+checksum = "a4da9b700e758e57152a1fd1c52cbdc5727c1aa6d8743dc1acda917398f1d76c"
 dependencies = [
  "adler32",
  "crc32fast",
@@ -1530,15 +1531,15 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "memchr"
@@ -1564,9 +1565,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "wasi",
@@ -1599,18 +1600,18 @@ checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "num-modular"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc41a1374056e9672221567958a66c16be12d0e2c1b408761e14d901c237d5e0"
+checksum = "bd8e500409e6cd603b03e477c26a6caecdc27ac58979a53e881c75eafc079f44"
 
 [[package]]
 name = "num-order"
@@ -1662,9 +1663,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -1672,9 +1673,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1682,9 +1683,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1695,9 +1696,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
 dependencies = [
  "pest",
 ]
@@ -1716,15 +1717,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -1746,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr3"
-version = "3.0.2"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e4dd828515431dd6c4a030d26f7eaed7dd4778226e9d2bb968d65ca4ec3d4d"
+checksum = "9e564d14133360e1ae169ffde5da25881b5fa47261665b8e5713c212c27799da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1756,14 +1757,14 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error3"
-version = "3.0.2"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee475e440453418ff1335189eddf7101ba502cd818ab7ae04209bc83aa925aa"
+checksum = "8f0d4471b3436c22106b21913b1dda531558918ae9b7ec55d58aa84b43552233"
 dependencies = [
  "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1804,9 +1805,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1941,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -1967,18 +1968,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2072,7 +2073,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2119,7 +2120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -2168,9 +2169,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "socket2"
@@ -2231,9 +2232,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2266,22 +2267,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2295,9 +2296,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -2325,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2351,20 +2352,20 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
  "rustls",
  "tokio",
@@ -2407,9 +2408,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
@@ -2572,9 +2573,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2625,9 +2626,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2638,9 +2639,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2648,22 +2649,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
@@ -2776,9 +2777,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "xmlparser"
@@ -2854,9 +2855,9 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2865,9 +2866,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2876,13 +2877,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2902,18 +2903,18 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.4"
+version = "7.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+checksum = "64d80649ab6db9d9f6f9c80a40becd948eda4714a0a5ac8c4d157a32231c7882"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
+version = "2.1.0+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+checksum = "0ef0a8027ec3ee71300ab3bcbcd0393f434aa72b91ca6d635a39941deae8eea0"
 dependencies = [
  "cc",
  "pkg-config",

--- a/clusters/al2023-arm64/eks.tf
+++ b/clusters/al2023-arm64/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "al2023-arm64"
   kubernetes_version = "1.34"

--- a/clusters/al2023-arm64/main.tf
+++ b/clusters/al2023-arm64/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
   }
 }

--- a/clusters/al2023-instance-storage/eks.tf
+++ b/clusters/al2023-instance-storage/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "al2023-instance-storage"
   kubernetes_version = "1.34"

--- a/clusters/al2023-instance-storage/main.tf
+++ b/clusters/al2023-instance-storage/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
   }
 }

--- a/clusters/al2023-x86-64/eks.tf
+++ b/clusters/al2023-x86-64/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "al2023-x86-64"
   kubernetes_version = "1.34"

--- a/clusters/al2023-x86-64/main.tf
+++ b/clusters/al2023-x86-64/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
   }
 }

--- a/clusters/auto-mode/eks.tf
+++ b/clusters/auto-mode/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "auto-mode"
   kubernetes_version = "1.34"

--- a/clusters/auto-mode/main.tf
+++ b/clusters/auto-mode/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
   }
 }

--- a/clusters/bottlerocket-arm64/eks.tf
+++ b/clusters/bottlerocket-arm64/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "bottlerocket-arm64"
   kubernetes_version = "1.34"

--- a/clusters/bottlerocket-arm64/main.tf
+++ b/clusters/bottlerocket-arm64/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
   }
 }

--- a/clusters/bottlerocket-x86-64/eks.tf
+++ b/clusters/bottlerocket-x86-64/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "bottlerocket-x86-64"
   kubernetes_version = "1.34"

--- a/clusters/bottlerocket-x86-64/main.tf
+++ b/clusters/bottlerocket-x86-64/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
   }
 }

--- a/clusters/default/eks.tf
+++ b/clusters/default/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/clusters/default/main.tf
+++ b/clusters/default/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
   }
 }

--- a/clusters/enable-all/eks.tf
+++ b/clusters/enable-all/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "enable-all"
   kubernetes_version = "1.34"

--- a/clusters/enable-all/main.tf
+++ b/clusters/enable-all/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
   }
 }

--- a/clusters/karpenter/eks.tf
+++ b/clusters/karpenter/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "karpenter"
   kubernetes_version = "1.34"

--- a/clusters/karpenter/helm.tf
+++ b/clusters/karpenter/helm.tf
@@ -4,7 +4,7 @@
 
 module "karpenter" {
   source  = "terraform-aws-modules/eks/aws//modules/karpenter"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   cluster_name = module.eks.cluster_name
 
@@ -27,7 +27,7 @@ resource "helm_release" "karpenter" {
   namespace  = "kube-system"
   repository = "oci://public.ecr.aws/karpenter"
   chart      = "karpenter"
-  version    = "1.14.0"
+  version    = "1.14.1"
   wait       = false
 
   values = [

--- a/clusters/karpenter/main.tf
+++ b/clusters/karpenter/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.2"
+      version = ">= 3.3"
     }
   }
 }

--- a/clusters/neuron-efa-cbr/eks.tf
+++ b/clusters/neuron-efa-cbr/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "neuron-efa-cbr"
   kubernetes_version = "1.34"

--- a/clusters/neuron-efa-cbr/helm.tf
+++ b/clusters/neuron-efa-cbr/helm.tf
@@ -6,7 +6,7 @@ resource "helm_release" "neuron" {
   name             = "neuron"
   repository       = "oci://public.ecr.aws/neuron"
   chart            = "neuron-helm-chart"
-  version          = "1.9.0"
+  version          = "1.10.0"
   namespace        = "neuron"
   create_namespace = true
   wait             = false
@@ -26,7 +26,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.29"
+  version    = "v0.5.30"
   wait       = false
 
   values = [

--- a/clusters/neuron-efa-cbr/main.tf
+++ b/clusters/neuron-efa-cbr/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.2"
+      version = ">= 3.3"
     }
   }
 }

--- a/clusters/neuron-efa/eks.tf
+++ b/clusters/neuron-efa/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "neuron-efa"
   kubernetes_version = "1.34"

--- a/clusters/neuron-efa/helm.tf
+++ b/clusters/neuron-efa/helm.tf
@@ -6,7 +6,7 @@ resource "helm_release" "neuron" {
   name             = "neuron"
   repository       = "oci://public.ecr.aws/neuron"
   chart            = "neuron-helm-chart"
-  version          = "1.9.0"
+  version          = "1.10.0"
   namespace        = "neuron"
   create_namespace = true
   wait             = false
@@ -26,7 +26,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.29"
+  version    = "v0.5.30"
   wait       = false
 
   values = [

--- a/clusters/neuron-efa/main.tf
+++ b/clusters/neuron-efa/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.2"
+      version = ">= 3.3"
     }
   }
 }

--- a/clusters/neuron/eks.tf
+++ b/clusters/neuron/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "neuron"
   kubernetes_version = "1.34"

--- a/clusters/neuron/helm.tf
+++ b/clusters/neuron/helm.tf
@@ -6,7 +6,7 @@ resource "helm_release" "neuron" {
   name             = "neuron"
   repository       = "oci://public.ecr.aws/neuron"
   chart            = "neuron-helm-chart"
-  version          = "1.9.0"
+  version          = "1.10.0"
   namespace        = "neuron"
   create_namespace = true
   wait             = false

--- a/clusters/neuron/main.tf
+++ b/clusters/neuron/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.2"
+      version = ">= 3.3"
     }
   }
 }

--- a/clusters/nvidia-cbr/eks.tf
+++ b/clusters/nvidia-cbr/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "nvidia-cbr"
   kubernetes_version = "1.34"

--- a/clusters/nvidia-cbr/helm.tf
+++ b/clusters/nvidia-cbr/helm.tf
@@ -6,7 +6,7 @@ resource "helm_release" "nvidia_device_plugin" {
   name             = "nvidia-device-plugin"
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
-  version          = "0.19.3"
+  version          = "0.20.0"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false

--- a/clusters/nvidia-cbr/main.tf
+++ b/clusters/nvidia-cbr/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.2"
+      version = ">= 3.3"
     }
   }
 }

--- a/clusters/nvidia-efa-cbr/eks.tf
+++ b/clusters/nvidia-efa-cbr/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "nvidia-efa-cbr"
   kubernetes_version = "1.34"

--- a/clusters/nvidia-efa-cbr/helm.tf
+++ b/clusters/nvidia-efa-cbr/helm.tf
@@ -6,7 +6,7 @@ resource "helm_release" "nvidia_device_plugin" {
   name             = "nvidia-device-plugin"
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
-  version          = "0.19.3"
+  version          = "0.20.0"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false
@@ -17,7 +17,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.29"
+  version    = "v0.5.30"
   wait       = false
 
   values = [

--- a/clusters/nvidia-efa-cbr/main.tf
+++ b/clusters/nvidia-efa-cbr/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.2"
+      version = ">= 3.3"
     }
   }
 }

--- a/clusters/nvidia-efa-odcr/eks.tf
+++ b/clusters/nvidia-efa-odcr/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "nvidia-efa-odcr"
   kubernetes_version = "1.34"

--- a/clusters/nvidia-efa-odcr/helm.tf
+++ b/clusters/nvidia-efa-odcr/helm.tf
@@ -6,7 +6,7 @@ resource "helm_release" "nvidia_device_plugin" {
   name             = "nvidia-device-plugin"
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
-  version          = "0.19.3"
+  version          = "0.20.0"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false
@@ -17,7 +17,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.29"
+  version    = "v0.5.30"
   wait       = false
 
   values = [

--- a/clusters/nvidia-efa-odcr/main.tf
+++ b/clusters/nvidia-efa-odcr/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.2"
+      version = ">= 3.3"
     }
   }
 }

--- a/clusters/nvidia-efa/eks.tf
+++ b/clusters/nvidia-efa/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "nvidia-efa"
   kubernetes_version = "1.34"

--- a/clusters/nvidia-efa/helm.tf
+++ b/clusters/nvidia-efa/helm.tf
@@ -6,7 +6,7 @@ resource "helm_release" "nvidia_device_plugin" {
   name             = "nvidia-device-plugin"
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
-  version          = "0.19.3"
+  version          = "0.20.0"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false
@@ -17,7 +17,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.29"
+  version    = "v0.5.30"
   wait       = false
 
   values = [

--- a/clusters/nvidia-efa/main.tf
+++ b/clusters/nvidia-efa/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.2"
+      version = ">= 3.3"
     }
   }
 }

--- a/clusters/nvidia/eks.tf
+++ b/clusters/nvidia/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "nvidia"
   kubernetes_version = "1.34"

--- a/clusters/nvidia/helm.tf
+++ b/clusters/nvidia/helm.tf
@@ -6,7 +6,7 @@ resource "helm_release" "nvidia_device_plugin" {
   name             = "nvidia-device-plugin"
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
-  version          = "0.19.3"
+  version          = "0.20.0"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false

--- a/clusters/nvidia/main.tf
+++ b/clusters/nvidia/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.2"
+      version = ">= 3.3"
     }
   }
 }

--- a/cookiecluster/src/inputs/mod.rs
+++ b/cookiecluster/src/inputs/mod.rs
@@ -396,10 +396,7 @@ fn should_enable_helm(
     _ => {}
   }
 
-  if accelerator != &compute::AcceleratorType::None || require_efa {
-    return true;
-  }
-  false
+  accelerator != &compute::AcceleratorType::None || require_efa
 }
 
 // Public ECR Helm resources are:

--- a/cookiecluster/src/snapshots/al2023-arm64/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/al2023-arm64/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/al2023-arm64/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/al2023-arm64/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
   }
 }

--- a/cookiecluster/src/snapshots/al2023-instance-storage/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/al2023-instance-storage/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/al2023-instance-storage/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/al2023-instance-storage/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
   }
 }

--- a/cookiecluster/src/snapshots/al2023-x86-64/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/al2023-x86-64/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/al2023-x86-64/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/al2023-x86-64/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
   }
 }

--- a/cookiecluster/src/snapshots/all-add-ons/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/all-add-ons/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/all-add-ons/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/all-add-ons/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
   }
 }

--- a/cookiecluster/src/snapshots/auto-mode-efa/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/auto-mode-efa/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/auto-mode-efa/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/auto-mode-efa/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
   }
 }

--- a/cookiecluster/src/snapshots/auto-mode-neuron/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/auto-mode-neuron/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/auto-mode-neuron/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/auto-mode-neuron/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
   }
 }

--- a/cookiecluster/src/snapshots/auto-mode-nvidia/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/auto-mode-nvidia/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/auto-mode-nvidia/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/auto-mode-nvidia/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
   }
 }

--- a/cookiecluster/src/snapshots/auto-mode/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/auto-mode/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/auto-mode/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/auto-mode/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
   }
 }

--- a/cookiecluster/src/snapshots/bottlerocket-arm64/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/bottlerocket-arm64/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/bottlerocket-arm64/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/bottlerocket-arm64/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
   }
 }

--- a/cookiecluster/src/snapshots/bottlerocket-nvidia/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/bottlerocket-nvidia/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/bottlerocket-nvidia/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/bottlerocket-nvidia/cookiecluster__cli__tests__helm.snap
@@ -11,7 +11,7 @@ resource "helm_release" "nvidia_device_plugin" {
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
   # Update to the latest compatible version: https://github.com/NVIDIA/k8s-device-plugin/releases
-  version          = "0.19.3"
+  version          = "0.20.0"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false

--- a/cookiecluster/src/snapshots/bottlerocket-nvidia/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/bottlerocket-nvidia/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.2"
+      version = ">= 3.3"
     }
   }
 }

--- a/cookiecluster/src/snapshots/bottlerocket-x86-64/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/bottlerocket-x86-64/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/bottlerocket-x86-64/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/bottlerocket-x86-64/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
   }
 }

--- a/cookiecluster/src/snapshots/cluster-autoscaler/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/cluster-autoscaler/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/cluster-autoscaler/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/cluster-autoscaler/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
   }
 }

--- a/cookiecluster/src/snapshots/default/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/default/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/default/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/default/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
   }
 }

--- a/cookiecluster/src/snapshots/enable-all/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/enable-all/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "cookiecluster"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/enable-all/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/enable-all/cookiecluster__cli__tests__main.snap
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
   }
 }

--- a/cookiecluster/src/snapshots/karpenter-odcr/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/karpenter-odcr/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/karpenter-odcr/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/karpenter-odcr/cookiecluster__cli__tests__helm.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "karpenter" {
   source  = "terraform-aws-modules/eks/aws//modules/karpenter"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   cluster_name = module.eks.cluster_name
 
@@ -32,7 +32,7 @@ resource "helm_release" "karpenter" {
   repository = "oci://public.ecr.aws/karpenter"
   chart      = "karpenter"
   # Update to the latest compatible version: https://github.com/aws/karpenter-provider-aws/releases
-  version    = "1.14.0"
+  version    = "1.14.1"
   wait       = false
 
   values = [
@@ -57,7 +57,7 @@ resource "helm_release" "nvidia_device_plugin" {
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
   # Update to the latest compatible version: https://github.com/NVIDIA/k8s-device-plugin/releases
-  version          = "0.19.3"
+  version          = "0.20.0"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false

--- a/cookiecluster/src/snapshots/karpenter-odcr/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/karpenter-odcr/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.2"
+      version = ">= 3.3"
     }
   }
 }

--- a/cookiecluster/src/snapshots/karpenter/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/karpenter/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/karpenter/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/karpenter/cookiecluster__cli__tests__helm.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "karpenter" {
   source  = "terraform-aws-modules/eks/aws//modules/karpenter"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   cluster_name = module.eks.cluster_name
 
@@ -32,7 +32,7 @@ resource "helm_release" "karpenter" {
   repository = "oci://public.ecr.aws/karpenter"
   chart      = "karpenter"
   # Update to the latest compatible version: https://github.com/aws/karpenter-provider-aws/releases
-  version    = "1.14.0"
+  version    = "1.14.1"
   wait       = false
 
   values = [

--- a/cookiecluster/src/snapshots/karpenter/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/karpenter/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.2"
+      version = ">= 3.3"
     }
   }
 }

--- a/cookiecluster/src/snapshots/neuron-cbr/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/neuron-cbr/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/neuron-cbr/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/neuron-cbr/cookiecluster__cli__tests__helm.snap
@@ -11,7 +11,7 @@ resource "helm_release" "neuron" {
   repository       = "oci://public.ecr.aws/neuron"
   chart            = "neuron-helm-chart"
   # Update to the latest compatible version: https://github.com/aws-neuron/neuron-helm-charts
-  version          = "1.9.0"
+  version          = "1.10.0"
   namespace        = "neuron"
   create_namespace = true
   wait             = false
@@ -31,7 +31,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.29"
+  version    = "v0.5.30"
   wait       = false
 
   values = [

--- a/cookiecluster/src/snapshots/neuron-cbr/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/neuron-cbr/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.2"
+      version = ">= 3.3"
     }
   }
 }

--- a/cookiecluster/src/snapshots/neuron-efa/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/neuron-efa/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/neuron-efa/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/neuron-efa/cookiecluster__cli__tests__helm.snap
@@ -11,7 +11,7 @@ resource "helm_release" "neuron" {
   repository       = "oci://public.ecr.aws/neuron"
   chart            = "neuron-helm-chart"
   # Update to the latest compatible version: https://github.com/aws-neuron/neuron-helm-charts
-  version          = "1.9.0"
+  version          = "1.10.0"
   namespace        = "neuron"
   create_namespace = true
   wait             = false
@@ -31,7 +31,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.29"
+  version    = "v0.5.30"
   wait       = false
 
   values = [

--- a/cookiecluster/src/snapshots/neuron-efa/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/neuron-efa/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.2"
+      version = ">= 3.3"
     }
   }
 }

--- a/cookiecluster/src/snapshots/neuron-odcr/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/neuron-odcr/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/neuron-odcr/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/neuron-odcr/cookiecluster__cli__tests__helm.snap
@@ -11,7 +11,7 @@ resource "helm_release" "neuron" {
   repository       = "oci://public.ecr.aws/neuron"
   chart            = "neuron-helm-chart"
   # Update to the latest compatible version: https://github.com/aws-neuron/neuron-helm-charts
-  version          = "1.9.0"
+  version          = "1.10.0"
   namespace        = "neuron"
   create_namespace = true
   wait             = false
@@ -31,7 +31,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.29"
+  version    = "v0.5.30"
   wait       = false
 
   values = [

--- a/cookiecluster/src/snapshots/neuron-odcr/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/neuron-odcr/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.2"
+      version = ">= 3.3"
     }
   }
 }

--- a/cookiecluster/src/snapshots/neuron/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/neuron/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/neuron/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/neuron/cookiecluster__cli__tests__helm.snap
@@ -11,7 +11,7 @@ resource "helm_release" "neuron" {
   repository       = "oci://public.ecr.aws/neuron"
   chart            = "neuron-helm-chart"
   # Update to the latest compatible version: https://github.com/aws-neuron/neuron-helm-charts
-  version          = "1.9.0"
+  version          = "1.10.0"
   namespace        = "neuron"
   create_namespace = true
   wait             = false

--- a/cookiecluster/src/snapshots/neuron/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/neuron/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.2"
+      version = ">= 3.3"
     }
   }
 }

--- a/cookiecluster/src/snapshots/nvidia-cbr/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/nvidia-cbr/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/nvidia-cbr/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/nvidia-cbr/cookiecluster__cli__tests__helm.snap
@@ -11,7 +11,7 @@ resource "helm_release" "nvidia_device_plugin" {
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
   # Update to the latest compatible version: https://github.com/NVIDIA/k8s-device-plugin/releases
-  version          = "0.19.3"
+  version          = "0.20.0"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false

--- a/cookiecluster/src/snapshots/nvidia-cbr/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/nvidia-cbr/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.2"
+      version = ">= 3.3"
     }
   }
 }

--- a/cookiecluster/src/snapshots/nvidia-efa-cbr/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/nvidia-efa-cbr/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/nvidia-efa-cbr/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/nvidia-efa-cbr/cookiecluster__cli__tests__helm.snap
@@ -11,7 +11,7 @@ resource "helm_release" "nvidia_device_plugin" {
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
   # Update to the latest compatible version: https://github.com/NVIDIA/k8s-device-plugin/releases
-  version          = "0.19.3"
+  version          = "0.20.0"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false
@@ -22,7 +22,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.29"
+  version    = "v0.5.30"
   wait       = false
 
   values = [

--- a/cookiecluster/src/snapshots/nvidia-efa-cbr/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/nvidia-efa-cbr/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.2"
+      version = ">= 3.3"
     }
   }
 }

--- a/cookiecluster/src/snapshots/nvidia-efa-odcr/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/nvidia-efa-odcr/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/nvidia-efa-odcr/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/nvidia-efa-odcr/cookiecluster__cli__tests__helm.snap
@@ -11,7 +11,7 @@ resource "helm_release" "nvidia_device_plugin" {
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
   # Update to the latest compatible version: https://github.com/NVIDIA/k8s-device-plugin/releases
-  version          = "0.19.3"
+  version          = "0.20.0"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false
@@ -22,7 +22,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.29"
+  version    = "v0.5.30"
   wait       = false
 
   values = [

--- a/cookiecluster/src/snapshots/nvidia-efa-odcr/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/nvidia-efa-odcr/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.2"
+      version = ">= 3.3"
     }
   }
 }

--- a/cookiecluster/src/snapshots/nvidia-no-efa/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/nvidia-no-efa/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/nvidia-no-efa/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/nvidia-no-efa/cookiecluster__cli__tests__helm.snap
@@ -11,7 +11,7 @@ resource "helm_release" "nvidia_device_plugin" {
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
   # Update to the latest compatible version: https://github.com/NVIDIA/k8s-device-plugin/releases
-  version          = "0.19.3"
+  version          = "0.20.0"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false

--- a/cookiecluster/src/snapshots/nvidia-no-efa/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/nvidia-no-efa/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.2"
+      version = ">= 3.3"
     }
   }
 }

--- a/cookiecluster/src/snapshots/nvidia/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/nvidia/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/nvidia/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/nvidia/cookiecluster__cli__tests__helm.snap
@@ -11,7 +11,7 @@ resource "helm_release" "nvidia_device_plugin" {
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
   # Update to the latest compatible version: https://github.com/NVIDIA/k8s-device-plugin/releases
-  version          = "0.19.3"
+  version          = "0.20.0"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false

--- a/cookiecluster/src/snapshots/nvidia/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/nvidia/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.2"
+      version = ">= 3.3"
     }
   }
 }

--- a/cookiecluster/src/snapshots/nvidia_efa/cookiecluster__cli__tests__eks.snap
+++ b/cookiecluster/src/snapshots/nvidia_efa/cookiecluster__cli__tests__eks.snap
@@ -8,7 +8,7 @@ expression: rendered
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "example"
   kubernetes_version = "1.34"

--- a/cookiecluster/src/snapshots/nvidia_efa/cookiecluster__cli__tests__helm.snap
+++ b/cookiecluster/src/snapshots/nvidia_efa/cookiecluster__cli__tests__helm.snap
@@ -11,7 +11,7 @@ resource "helm_release" "nvidia_device_plugin" {
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
   # Update to the latest compatible version: https://github.com/NVIDIA/k8s-device-plugin/releases
-  version          = "0.19.3"
+  version          = "0.20.0"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false
@@ -22,7 +22,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.29"
+  version    = "v0.5.30"
   wait       = false
 
   values = [

--- a/cookiecluster/src/snapshots/nvidia_efa/cookiecluster__cli__tests__main.snap
+++ b/cookiecluster/src/snapshots/nvidia_efa/cookiecluster__cli__tests__main.snap
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.2"
+      version = ">= 3.3"
     }
   }
 }

--- a/cookiecluster/templates/eks.tpl
+++ b/cookiecluster/templates/eks.tpl
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   name               = "{{ inputs.name }}"
   kubernetes_version = "{{ inputs.kubernetes_version }}"

--- a/cookiecluster/templates/helm.tpl
+++ b/cookiecluster/templates/helm.tpl
@@ -6,7 +6,7 @@
 
 module "karpenter" {
   source  = "terraform-aws-modules/eks/aws//modules/karpenter"
-  version = "~> 21.24"
+  version = "~> 21.25"
 
   cluster_name = module.eks.cluster_name
 
@@ -30,7 +30,7 @@ resource "helm_release" "karpenter" {
   repository = "oci://public.ecr.aws/karpenter"
   chart      = "karpenter"
   # Update to the latest compatible version: https://github.com/aws/karpenter-provider-aws/releases
-  version    = "1.14.0"
+  version    = "1.14.1"
   wait       = false
 
   values = [
@@ -57,7 +57,7 @@ resource "helm_release" "nvidia_device_plugin" {
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
   # Update to the latest compatible version: https://github.com/NVIDIA/k8s-device-plugin/releases
-  version          = "0.19.3"
+  version          = "0.20.0"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false
@@ -70,7 +70,7 @@ resource "helm_release" "neuron" {
   repository       = "oci://public.ecr.aws/neuron"
   chart            = "neuron-helm-chart"
   # Update to the latest compatible version: https://github.com/aws-neuron/neuron-helm-charts
-  version          = "1.9.0"
+  version          = "1.10.0"
   namespace        = "neuron"
   create_namespace = true
   wait             = false
@@ -92,7 +92,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.29"
+  version    = "v0.5.30"
   wait       = false
 
   values = [

--- a/cookiecluster/templates/main.tpl
+++ b/cookiecluster/templates/main.tpl
@@ -4,12 +4,12 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.55"
+      version = ">= 6.63"
     }
     {{ #if inputs.enable_helm }}
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 3.2"
+      version = ">= 3.3"
     }
     {{ /if }}
   }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,9 +10,9 @@ edition.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-aws-config = {version="1.10", features=["behavior-version-latest"]}
-aws-types = "1.5"
-aws-sdk-ec2 = { version = "1.241", default-features = false, features = ["default-https-client", "rt-tokio"] }
+aws-config = {version="1.12", features=["behavior-version-latest"]}
+aws-types = "1.6"
+aws-sdk-ec2 = { version = "1.254", default-features = false, features = ["default-https-client", "rt-tokio"] }
 handlebars = "6.4"
 serde.workspace = true
 serde_json = "1.0"


### PR DESCRIPTION
Bumps every dependency to its true latest, including the AWS SDK crates that Dependabot was chasing piecemeal.

- aws-config 1.10 -> 1.12
- aws-types 1.5 -> 1.6
- aws-sdk-ec2 1.241 -> 1.254
- dtolnay/rust-toolchain SHA bumped to the current master tip (this action has no versioned releases, it is pinned by commit and was over four years stale)
- orhun/git-cliff-action v4.8.0 -> v4.9.0
- pre-commit-terraform v1.108.0 -> v1.109.1
- terraform-aws-modules/eks/aws ~> 21.24 -> ~> 21.25
- hashicorp/aws provider >= 6.55 -> >= 6.63
- hashicorp/helm provider >= 3.2 -> >= 3.3
- karpenter chart 1.14.0 -> 1.14.1
- neuron-helm-chart 1.9.0 -> 1.10.0
- aws-efa-k8s-device-plugin v0.5.29 -> v0.5.30
- nvidia-device-plugin chart 0.19.3 -> 0.20.0

The Terraform version bumps landed in three places kept in lockstep: the `clusters/` example configs, the `cookiecluster/templates/*.tpl` files those examples are rendered from, and the insta snapshot fixtures that assert on the rendered output, so the CLI's actual generated output moves together with the examples instead of drifting from them. All 17 workspaces under `clusters/` pass `terraform init -upgrade` and `terraform validate` against the new module and provider constraints. actions/checkout, actions/cache, and svenstaro/upload-release-action were already at latest. clowdhaus/tags/aws is already at its latest published version (2.1.0), so its `~> 2.1` constraint is unchanged. The three whitespace-fixing pre-commit hooks now exclude `cookiecluster/src/snapshots/`. Those snapshots are byte-exact fixtures of rendered Terraform and 21 of them carry trailing whitespace the renderer emits, so running the hooks unexcluded rewrites all 21 and breaks every snapshot assertion, which is what happens if you run them on `main` today. `check-merge-conflict` still covers the snapshots because it only reports and never rewrites.

The AWS SDK crates now carry a minimum supported Rust version of 1.94.1, above the 1.93.0 toolchain on this machine, but every CI job installs Rust via `nightly`, so this should not affect the build.

Supersedes #98.

